### PR TITLE
feature: function hoisting

### DIFF
--- a/examples/hoisting.tn
+++ b/examples/hoisting.tn
@@ -1,0 +1,5 @@
+dbg(name())
+
+fn name() {
+    return "Ryan"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod compiler;
 mod value;
 mod code;
 mod vm;
+mod passes;
 
 pub use token::{TokenKind, Token, Span};
 pub use lexer::Lexer;
@@ -35,7 +36,7 @@ fn main() {
 
     let (filename, source) = source();
 
-    let ast = match Parser::new(Lexer::new(&source[..])).parse() {
+    let mut ast = match Parser::new(Lexer::new(&source[..])).parse() {
         Ok(ast) => ast,
         Err(ParserError { line, span, err }) => {
             Report::build(ReportKind::Error, &filename, line)
@@ -77,6 +78,8 @@ fn main() {
             exit(1);
         },
     };
+
+    passes::pass(&mut ast);
 
     #[cfg(debug_assertions)]
     dbg!(&ast);

--- a/src/passes/mod.rs
+++ b/src/passes/mod.rs
@@ -1,0 +1,14 @@
+use crate::Statement;
+use std::cmp::Ordering;
+
+pub fn pass(ast: &mut Vec<Statement>) {
+    hoist_functions(ast);
+}
+
+fn hoist_functions(ast: &mut Vec<Statement>) {
+    ast.sort_unstable_by(|a, _| if matches!(a, Statement::Function { .. }) {
+        Ordering::Less
+    } else {
+        Ordering::Equal
+    });
+}


### PR DESCRIPTION
Adds support for function hoisting, meaning all function definitions are placed at the top of the AST, e.g.

```rust
dbg(name())

fn name() {
    return "Ryan"
}
```

This will now work as `name()` is defined before the `dbg()` call. This is the simplest way to make this work, an alternative way of doing this would be creating a pseudo-main function that is wrapped around all procedural statements instead. That could be a potential refactor later on, but this is good for now.