### PR TITLE
feature: closures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "tonic"
 version = "0.1.0"
 dependencies = [
  "ariadne",
+ "rand",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 ariadne = "0.1.3"
+rand = "0.7.3"
 
 [profile.release]
 debug = true

--- a/examples/closure-with-clashes.tn
+++ b/examples/closure-with-clashes.tn
@@ -1,0 +1,8 @@
+let name = "Ryan"
+
+let dbg_name = fn (name) {
+    dbg("Shouldn't output Ryan")
+    dbg(name)
+}
+
+dbg_name("Peter")

--- a/examples/closures.tn
+++ b/examples/closures.tn
@@ -1,0 +1,7 @@
+let name = "Ryan"
+
+let dbg_name = fn () {
+    dbg(name)
+}
+
+dbg_name()

--- a/examples/iife.tn
+++ b/examples/iife.tn
@@ -1,0 +1,3 @@
+(fn () {
+    dbg("Hello, IIFE!")
+})()

--- a/src/code.rs
+++ b/src/code.rs
@@ -1,10 +1,12 @@
-use crate::{Value, Op};
+use crate::{Value, Op, Function};
 
 #[derive(Debug, Clone)]
 pub enum Code {
     // name of the label (function name), position to jump to to skip over function
     Label(String, usize),
     Constant(Value),
+    // A special code used to capture the current frame's environment and store alongside the closure.
+    Closure(Function),
     Array(usize),
     Set(String),
     Get(String),

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,4 +1,5 @@
 use crate::TokenKind;
+use crate::{Parameter, Statement};
 
 #[derive(Debug, PartialEq)]
 pub enum Expression {
@@ -13,6 +14,7 @@ pub enum Expression {
     Assign(Box<Expression>, Box<Expression>),
     SetProperty(Box<Expression>, Box<Expression>),
     GetProperty(Box<Expression>, Option<Box<Expression>>),
+    Closure(Vec<Parameter>, Vec<Statement>),
 }
 
 impl Expression {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -242,6 +242,22 @@ impl<'p> Parser<'p> {
 
                 Expression::Array(items)
             },
+            TokenKind::Fn => {
+                self.expect(TokenKind::Fn)?;
+
+                self.expect(TokenKind::LeftParen)?;
+
+                let params = self.parameters()?;
+
+                self.expect(TokenKind::RightParen)?;
+                self.expect(TokenKind::LeftBrace)?;
+
+                let body = self.block(TokenKind::RightBrace)?;
+
+                self.expect(TokenKind::RightBrace)?;
+
+                Expression::Closure(params, body)
+            },
             _ if is_prefix(&self.current.kind) => {
                 let kind = self.current.kind.clone();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -258,6 +258,15 @@ impl<'p> Parser<'p> {
 
                 Expression::Closure(params, body)
             },
+            TokenKind::LeftParen => {
+                self.expect(TokenKind::LeftParen)?;
+
+                let expression = self.expression(0)?;
+
+                self.expect(TokenKind::RightParen)?;
+
+                expression
+            },
             _ if is_prefix(&self.current.kind) => {
                 let kind = self.current.kind.clone();
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -40,7 +40,7 @@ pub enum Statement {
 /// The `Parameter` struct is used to represent a function parameter.
 /// 
 /// It stores information about the name of the parameter and the expected type of the parameter.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Parameter {
     pub name: String,
     pub r#type: Option<Type>,

--- a/src/type.rs
+++ b/src/type.rs
@@ -1,5 +1,5 @@
 // The `Type` enumeration is the single-source of truth for type strings in Tonic.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Type {
     String,
     Bool,

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::ops::{Add, Sub, Mul, Div};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -141,6 +142,7 @@ impl Value {
 #[derive(Clone)]
 pub enum Function {
     User(String, usize),
+    Closure(usize, HashMap<String, Value>),
     Internal(&'static str, InternalFunction),
 }
 
@@ -149,6 +151,7 @@ impl std::fmt::Debug for Function {
         match self {
             Function::User(name, _) => write!(f, "{}()", name),
             Function::Internal(name, _) => write!(f, "InternalFunction<{}>", name),
+            Function::Closure(scope, _) => write!(f, "Closure<{}>", scope),
         }
     }
 }


### PR DESCRIPTION
Closes #16.

This is quite a dirty way of doing I feel. We essentially create a special opcode for closures. This code will take the environment of the current frame and store it inside of the closure value so that it can be restored (set with frame) when called later on.

When we move to stack offsets, we'll likely need to capture those stack offsets instead.